### PR TITLE
update URLs for support matrix and CLA landing page

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,4 +74,4 @@ See the License for the specific language governing permissions and
 limitations under the License.
  
 ### Contributor License Agreement
-Individuals or business entities who contribute to this project must have completed and submitted the [F5 Contributor License Agreement](http://f5networks.github.io/f5-openstack-docs/cla_landing/index.html) to Openstack_CLA@f5.com prior to their code submission being included in this project.
+Individuals or business entities who contribute to this project must have completed and submitted the [F5 Contributor License Agreement](http://f5-openstack-docs.readthedocs.org/en/latest/cla_landing.html) to Openstack_CLA@f5.com prior to their code submission being included in this project.

--- a/README.rst
+++ b/README.rst
@@ -13,7 +13,7 @@ Releases and Versions
 This branch supports the OpenStack Kilo release.
 
 For more information about F5 Networks's OpenStack versioning and a support
-matrix please see `F5 Networks OpenStack Support Matrix <https://F5Networks.github.io/f5-openstack-docs>`__.
+matrix please see `F5 Networks OpenStack Support Matrix <http://f5-openstack-docs.readthedocs.org/en/latest/releases_and_versioning.html>`__.
 
 Installation
 ------------
@@ -140,7 +140,7 @@ Contributor License Agreement
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Individuals or business entities who contribute to this project must
 have completed and submitted the `F5 Contributor License
-Agreement <http://f5networks.github.io/f5-openstack-docs/cla_landing/index.html>`__
+Agreement <http://f5-openstack-docs.readthedocs.org/en/latest/cla_landing.html>`__
 to Openstack_CLA@f5.com prior to their code submission being included in this
 project.
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -12,7 +12,7 @@ Releases and Versions
 |release| supports the OpenStack |openstack_release| release.
 
 For more information about F5 Networks's OpenStack versioning and a support
-matrix please see `F5 Networks OpenStack Support Matrix <https://F5Networks.github.io/f5-openstack-docs>`__.
+matrix please see `F5 Networks OpenStack Support Matrix <http://f5-openstack-docs.readthedocs.org/en/latest/releases_and_versioning.html>`__.
 
 Installation
 ------------
@@ -86,7 +86,7 @@ Contributor License Agreement
 
 Individuals or business entities who contribute to this project must
 have completed and submitted the `F5 Contributor License
-Agreement <http://f5networks.github.io/f5-openstack-docs/cla_landing/index.html>`__
+Agreement <http://f5-openstack-docs.readthedocs.org/en/latest/cla_landing.html>`__
 to Openstack_CLA@f5.com prior to their code submission being included in this
 project.
 


### PR DESCRIPTION
Fixes #1 
@swormke 
#### What's this change do?

Changed the urls for the support matrix and CLA landing page from the github.io pages to the new read the docs pages.
#### Where should the reviewer start?

view the changes below
#### Any background context?

I initially made the change on the kilo branch but there was a merge conflict, so I cherry-picked it over to master instead. 
