### PR TITLE
Fix heat stack delete failures

### DIFF
--- a/f5_heat/resources/common/mixins.py
+++ b/f5_heat/resources/common/mixins.py
@@ -18,7 +18,7 @@ def f5_common_resources(func):
     def func_wrapper(self, *args, **kwargs):
         self.get_bigip()
         self.set_partition_name()
-        func(self, *args, **kwargs)
+        return func(self, *args, **kwargs)
     return func_wrapper
 
 

--- a/f5_heat/resources/f5_bigip_device.py
+++ b/f5_heat/resources/f5_bigip_device.py
@@ -52,6 +52,7 @@ class F5BigIPDevice(resource.Resource):
 
     def __init__(self, name, definition, stack):
         super(F5BigIPDevice, self).__init__(name, definition, stack)
+        self.bigip = None
         try:
             self.bigip = BigIP(
                 self.properties['ip'],

--- a/f5_heat/resources/f5_ltm_pool.py
+++ b/f5_heat/resources/f5_ltm_pool.py
@@ -141,14 +141,19 @@ class F5LTMPool(resource.Resource, F5BigIPMixin):
         :raises: ResourceFailure
         '''
 
-        try:
-            loaded_pool = self.bigip.ltm.pools.pool.load(
+        if self.bigip.ltm.pools.pool.exists(
                 name=self.properties[self.NAME],
                 partition=self.partition_name
-            )
-            loaded_pool.delete()
-        except Exception as ex:
-            raise exception.ResourceFailure(ex, None, action='DELETE')
+        ):
+            try:
+                loaded_pool = self.bigip.ltm.pools.pool.load(
+                    name=self.properties[self.NAME],
+                    partition=self.partition_name
+                )
+                loaded_pool.delete()
+            except Exception as ex:
+                raise exception.ResourceFailure(ex, None, action='DELETE')
+        return True
 
 
 def resource_mapping():

--- a/f5_heat/resources/f5_ltm_virtualserver.py
+++ b/f5_heat/resources/f5_ltm_virtualserver.py
@@ -116,15 +116,19 @@ class F5LTMVirtualServer(resource.Resource, F5BigIPMixin):
 
         :raises: ResourceFailure exception
         '''
-
-        try:
-            loaded_pool = self.bigip.ltm.virtuals.virtual.load(
+        if self.bigip.ltm.virtuals.virtual.exists(
                 name=self.properties[self.NAME],
                 partition=self.partition_name
-            )
-            loaded_pool.delete()
-        except Exception as ex:
-            raise exception.ResourceFailure(ex, None, action='DELETE')
+        ):
+            try:
+                loaded_pool = self.bigip.ltm.virtuals.virtual.load(
+                    name=self.properties[self.NAME],
+                    partition=self.partition_name
+                )
+                loaded_pool.delete()
+            except Exception as ex:
+                raise exception.ResourceFailure(ex, None, action='DELETE')
+        return True
 
 
 def resource_mapping():

--- a/f5_heat/resources/f5_sys_iappcompositetemplate.py
+++ b/f5_heat/resources/f5_sys_iappcompositetemplate.py
@@ -143,15 +143,20 @@ class F5SysiAppCompositeTemplate(F5BigIPMixin, resource.Resource):
         :raises: ResourceFailure
         '''
 
-        try:
-            loaded_template = self.bigip.sys.applications.templates.template.\
-                load(
-                    name=self.properties[self.NAME],
-                    partition=self.partition_name
-                )
-            loaded_template.delete()
-        except Exception as ex:
-            raise exception.ResourceFailure(ex, None, action='DELETE')
+        if self.bigip.sys.applications.templates.template.exists(
+                name=self.properties[self.NAME],
+                partition=self.partition_name
+        ):
+            try:
+                loaded_template = self.bigip.sys.applications.templates.template.\
+                    load(
+                        name=self.properties[self.NAME],
+                        partition=self.partition_name
+                    )
+                loaded_template.delete()
+            except Exception as ex:
+                raise exception.ResourceFailure(ex, None, action='DELETE')
+        return True
 
 
 def resource_mapping():

--- a/f5_heat/resources/f5_sys_partition.py
+++ b/f5_heat/resources/f5_sys_partition.py
@@ -91,14 +91,19 @@ class F5SysPartition(resource.Resource, F5BigIPMixin):
 
         :raises: ResourceFailure exception
         '''
-        if self.properties[self.NAME] != 'Common':
-            try:
-                loaded_partition = self.bigip.sys.folders.folder.load(
-                    name=self.properties[self.NAME]
-                )
-                loaded_partition.delete()
-            except Exception as ex:
-                raise exception.ResourceFailure(ex, None, action='DELETE')
+
+        if self.bigip.sys.folders.folder.exists(
+                name=self.properties[self.NAME]
+        ):
+            if self.properties[self.NAME] != 'Common':
+                try:
+                    loaded_partition = self.bigip.sys.folders.folder.load(
+                        name=self.properties[self.NAME]
+                    )
+                    loaded_partition.delete()
+                except Exception as ex:
+                    raise exception.ResourceFailure(ex, None, action='DELETE')
+        return True
 
 
 def resource_mapping():

--- a/f5_heat/resources/test/test_f5_ltm_pool.py
+++ b/f5_heat/resources/test/test_f5_ltm_pool.py
@@ -120,6 +120,22 @@ def F5LTMPool():
 
 
 @pytest.fixture
+def F5LTMPoolExists(F5LTMPool):
+    F5LTMPool.get_bigip()
+    mock_exists = mock.MagicMock(return_value=True)
+    F5LTMPool.bigip.ltm.pools.pool.exists.side_effect = mock_exists
+    return F5LTMPool
+
+
+@pytest.fixture
+def F5LTMPoolNoExists(F5LTMPool):
+    F5LTMPool.get_bigip()
+    mock_exists = mock.MagicMock(return_value=False)
+    F5LTMPool.bigip.ltm.pools.pool.exists.side_effect = mock_exists
+    return F5LTMPool
+
+
+@pytest.fixture
 def CreatePoolSideEffect(F5LTMPool):
     F5LTMPool.get_bigip()
     F5LTMPool.bigip.ltm.pools.pool.create.side_effect = Exception()
@@ -165,10 +181,14 @@ def test_handle_create_assign_members_error(AssignMembersSideEffect):
         AssignMembersSideEffect.handle_create()
 
 
-def test_handle_delete(F5LTMPool):
-    assert F5LTMPool.handle_delete() is None
-    assert F5LTMPool.bigip.ltm.pools.pool.load.call_args == \
+def test_handle_delete(F5LTMPoolExists):
+    assert F5LTMPoolExists.handle_delete() is True
+    assert F5LTMPoolExists.bigip.ltm.pools.pool.load.call_args == \
         mock.call(name='testing_pool', partition='Common')
+
+
+def test_handle_delete_no_exists(F5LTMPoolNoExists):
+    assert F5LTMPoolNoExists.handle_delete() is True
 
 
 def test_handle_delete_error(DeletePoolSideEffect):

--- a/f5_heat/resources/test/test_f5_ltm_virtualserver.py
+++ b/f5_heat/resources/test/test_f5_ltm_virtualserver.py
@@ -120,6 +120,22 @@ def F5LTMVirtualServer():
 
 
 @pytest.fixture
+def F5LTMVirtualServerExists(F5LTMVirtualServer):
+    F5LTMVirtualServer.get_bigip()
+    mock_exists = mock.MagicMock(return_value=True)
+    F5LTMVirtualServer.bigip.ltm.virtuals.virtual.exists = mock_exists
+    return F5LTMVirtualServer
+
+
+@pytest.fixture
+def F5LTMVirtualServerNoExists(F5LTMVirtualServer):
+    F5LTMVirtualServer.get_bigip()
+    mock_exists = mock.MagicMock(return_value=False)
+    F5LTMVirtualServer.bigip.ltm.virtuals.virtual.exists = mock_exists
+    return F5LTMVirtualServer
+
+
+@pytest.fixture
 def CreateVirtualServerSideEffect(F5LTMVirtualServer):
     F5LTMVirtualServer.get_bigip()
     F5LTMVirtualServer.bigip.ltm.virtuals.virtual.create.side_effect = \
@@ -156,13 +172,17 @@ def test_handle_create_error(CreateVirtualServerSideEffect):
         CreateVirtualServerSideEffect.handle_create()
 
 
-def test_handle_delete(F5LTMVirtualServer):
-    assert None == F5LTMVirtualServer.handle_delete()
-    assert F5LTMVirtualServer.bigip.ltm.virtuals.virtual.load.call_args == \
+def test_handle_delete(F5LTMVirtualServerExists):
+    assert F5LTMVirtualServerExists.handle_delete() is True
+    assert F5LTMVirtualServerExists.bigip.ltm.virtuals.virtual.load.call_args == \
         mock.call(
             name=u'testing_vs',
             partition='Common'
         )
+
+
+def test_handle_delete_no_exists(F5LTMVirtualServerNoExists):
+    assert F5LTMVirtualServerNoExists.handle_delete() is True
 
 
 def test_handle_delete_error(DeleteVirtualServerSideEffect):

--- a/f5_heat/resources/test/test_f5_sys_iappcompositetemplate.py
+++ b/f5_heat/resources/test/test_f5_sys_iappcompositetemplate.py
@@ -138,6 +138,16 @@ def F5SysiAppTemplate():
 
 
 @pytest.fixture
+def F5SysiAppTemplateNoExists(F5SysiAppTemplate):
+    '''Instantiate the F5SysiAppTemplate resource.'''
+    F5SysiAppTemplate.get_bigip()
+    mock_exists = mock.MagicMock(return_value=False)
+    F5SysiAppTemplate.bigip.sys.applications.templates.template.exists = \
+        mock_exists
+    return F5SysiAppTemplate
+
+
+@pytest.fixture
 def CreateTemplateSideEffect(F5SysiAppTemplate):
     F5SysiAppTemplate.get_bigip()
     F5SysiAppTemplate.bigip.sys.applications.templates.template.create.\
@@ -177,10 +187,13 @@ def test_handle_create_error(CreateTemplateSideEffect):
 
 
 def test_handle_delete(F5SysiAppTemplate):
-    delete_result = F5SysiAppTemplate.handle_delete()
-    assert delete_result is None
+    assert F5SysiAppTemplate.handle_delete() is True
     assert F5SysiAppTemplate.bigip.sys.applications.templates.template.load.\
         call_args == mock.call(name='testing_template', partition='Common')
+
+
+def test_handle_delete_no_exists(F5SysiAppTemplateNoExists):
+    assert F5SysiAppTemplateNoExists.handle_delete() is True
 
 
 def test_handle_delete_error(DeleteTemplateSideEffect):

--- a/f5_heat/resources/test/test_f5_sys_iappfulltemplate.py
+++ b/f5_heat/resources/test/test_f5_sys_iappfulltemplate.py
@@ -154,6 +154,26 @@ def F5SysiAppTemplate():
 
 
 @pytest.fixture
+def F5SysiAppTemplateExists(F5SysiAppTemplate):
+    '''Instantiate the F5SysiAppTemplate resource.'''
+    F5SysiAppTemplate.get_bigip()
+    mock_exists = mock.MagicMock(return_value=True)
+    F5SysiAppTemplate.bigip.sys.applications.templates.template.exists = \
+        mock_exists
+    return F5SysiAppTemplate
+
+
+@pytest.fixture
+def F5SysiAppTemplateNoExists(F5SysiAppTemplate):
+    '''Instantiate the F5SysiAppTemplate resource.'''
+    F5SysiAppTemplate.get_bigip()
+    mock_exists = mock.MagicMock(return_value=False)
+    F5SysiAppTemplate.bigip.sys.applications.templates.template.exists = \
+        mock_exists
+    return F5SysiAppTemplate
+
+
+@pytest.fixture
 def CreateTemplateSideEffect(F5SysiAppTemplate):
     F5SysiAppTemplate.get_bigip()
     F5SysiAppTemplate.bigip.sys.applications.templates.template.create.\
@@ -192,11 +212,15 @@ def test_handle_create_error(CreateTemplateSideEffect):
         CreateTemplateSideEffect.handle_create()
 
 
-def test_handle_delete(F5SysiAppTemplate):
-    delete_result = F5SysiAppTemplate.handle_delete()
-    assert delete_result is None
-    assert F5SysiAppTemplate.bigip.sys.applications.templates.template.load.\
+def test_handle_delete(F5SysiAppTemplateExists):
+    delete_result = F5SysiAppTemplateExists.handle_delete()
+    assert delete_result is True
+    assert F5SysiAppTemplateExists.bigip.sys.applications.templates.template.load.\
         call_args == mock.call(name='testing_template', partition='Common')
+
+
+def test_handle_delete_no_exists(F5SysiAppTemplateNoExists):
+    assert F5SysiAppTemplateNoExists.handle_delete() is True
 
 
 def test_handle_delete_error(DeleteTemplateSideEffect):

--- a/f5_heat/resources/test/test_f5_sys_iappservice.py
+++ b/f5_heat/resources/test/test_f5_sys_iappservice.py
@@ -155,6 +155,24 @@ def F5SysiAppService():
 
 
 @pytest.fixture
+def F5SysiAppServiceExists(F5SysiAppService):
+    F5SysiAppService.get_bigip()
+    mock_exists = mock.MagicMock(return_value=True)
+    F5SysiAppService.bigip.sys.applications.services.service.exists = \
+        mock_exists
+    return F5SysiAppService
+
+
+@pytest.fixture
+def F5SysiAppServiceNoExists(F5SysiAppService):
+    F5SysiAppService.get_bigip()
+    mock_exists = mock.MagicMock(return_value=False)
+    F5SysiAppService.bigip.sys.applications.services.service.exists = \
+        mock_exists
+    return F5SysiAppService
+
+
+@pytest.fixture
 def CreateServiceSideEffect(F5SysiAppService):
     F5SysiAppService.get_bigip()
     F5SysiAppService.bigip.sys.applications.services.service.create.\
@@ -191,11 +209,14 @@ def test_handle_create_error(CreateServiceSideEffect):
         CreateServiceSideEffect.handle_create()
 
 
-def test_handle_delete(F5SysiAppService):
-    delete_result = F5SysiAppService.handle_delete()
-    assert delete_result is None
-    assert F5SysiAppService.bigip.sys.applications.services.service.load.\
+def test_handle_delete(F5SysiAppServiceExists):
+    assert F5SysiAppServiceExists.handle_delete() is True
+    assert F5SysiAppServiceExists.bigip.sys.applications.services.service.load.\
         call_args == mock.call(name=u'testing_service', partition='Common')
+
+
+def test_handle_delete_no_exists(F5SysiAppServiceNoExists):
+    assert F5SysiAppServiceNoExists.handle_delete() is True
 
 
 def test_handle_delete_error(DeleteServiceSideEffect):


### PR DESCRIPTION
@zancas 
#### What's this change do?

Fixes failed deletes of heat stacks when resources fail
#### Any background context?

When deleting a heat stack, resources can fail to delete and the stack is permanently broken. The fix is to delete f5 resources in a smarter way, that is, check if that resource exists on the BigIP device, and if it does, delete it. Otherwise, no action needs to be taken.
#### Where should the reviewer start?

New and modified unit tests.
