### PR TITLE
LTM Pool resource does not skip adding members if no members are presented in heat template

### DIFF
--- a/f5_heat/resources/f5_ltm_pool.py
+++ b/f5_heat/resources/f5_ltm_pool.py
@@ -103,7 +103,7 @@ class F5LTMPool(resource.Resource, F5BigIPMixin):
                     name=self.properties[self.NAME],
                     partition=self.partition_name
                 )
-                loaded_pool.members_s.member.create(
+                loaded_pool.members_s.members.create(
                     name=member_name,
                     partition=self.partition_name,
                     address=member_ip
@@ -131,7 +131,8 @@ class F5LTMPool(resource.Resource, F5BigIPMixin):
         except Exception as ex:
             raise exception.ResourceFailure(ex, None, action='CREATE')
 
-        self._assign_members()
+        if self.properties[self.MEMBERS]:
+            self._assign_members()
         self.resource_id_set(self.physical_resource_name())
 
     @f5_common_resources

--- a/f5_heat/resources/test/test_f5_ltm_pool.py
+++ b/f5_heat/resources/test/test_f5_ltm_pool.py
@@ -145,7 +145,7 @@ def CreatePoolSideEffect(F5LTMPool):
 @pytest.fixture
 def AssignMembersSideEffect(F5LTMPool):
     F5LTMPool.get_bigip()
-    F5LTMPool.bigip.ltm.pools.pool.load().members_s.member.create.side_effect = \
+    F5LTMPool.bigip.ltm.pools.pool.load().members_s.members.create.side_effect = \
         exception.ResourceFailure(mock.MagicMock(), None, action='ADD MEMBERS')
     return F5LTMPool
 


### PR DESCRIPTION
@szakeri 

Issues: Fixes: Issue #13

Problem: Need a check to skip adding members if none given through
resource properties.

Analysis: Fixed two bugs in this resource. One is the check to add
members and the other is the reference to a member which is actually
named members.

Tests: All tests pass
