### PR TITLE
Branding compliance updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ var/
 *.egg-info/
 .installed.cfg
 *.egg
+venv/*
 
 # PyInstaller
 #  Usually these files are written by a python script from a template

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,7 +56,7 @@ shell
 $ py.test --cov ./ --cov-report=html
 $ open htmlcov/index.html
 ```
-If you are running our functional tests you will need a real BIG-IP to run them against, but you can get one of those pretty easily in [Amazon EC2](https://aws.amazon.com/marketplace/pp/B00JL3UASY/ref=srh_res_product_title?ie=UTF8&sr=0-10&qid=1449332167461).
+If you are running our functional tests you will need a real BIG-IP®  to run them against, but you can get one of those pretty easily in [Amazon EC2](https://aws.amazon.com/marketplace/pp/B00JL3UASY/ref=srh_res_product_title?ie=UTF8&sr=0-10&qid=1449332167461).
 
 ## License
  
@@ -74,4 +74,4 @@ See the License for the specific language governing permissions and
 limitations under the License.
  
 ### Contributor License Agreement
-Individuals or business entities who contribute to this project must have completed and submitted the [F5 Contributor License Agreement](http://f5-openstack-docs.readthedocs.org/en/latest/cla_landing.html) to Openstack_CLA@f5.com prior to their code submission being included in this project.
+Individuals or business entities who contribute to this project must have completed and submitted the [F5® Contributor License Agreement](http://f5-openstack-docs.readthedocs.org/en/latest/cla_landing.html) to Openstack_CLA@f5.com prior to their code submission being included in this project.

--- a/README.rst
+++ b/README.rst
@@ -8,16 +8,15 @@ f5-openstack-heat-plugins
 
 Introduction
 ------------
-This repository houses all of F5's OpenStack Heat resource plugins. F5's
-Heat plugins can be used to orchestrate BIG-IP services in your
-OpenStack environment.
+This repository houses all of F5®'s OpenStack Heat resource plugins. F5®'s
+Heat plugins can be used to orchestrate BIG-IP®  services in your OpenStack environment.
 
 Releases and Versions
 ---------------------
 This branch supports the OpenStack Kilo release.
 
-For more information about F5 Networks's OpenStack versioning and a support
-matrix please see `F5 Networks OpenStack Support Matrix <http://f5-openstack-docs.readthedocs.org/en/latest/releases_and_versioning.html>`__.
+For more information about F5® Networks's OpenStack versioning and a support
+matrix please see `F5® Networks OpenStack Support Matrix <http://f5-openstack-docs.readthedocs.org/en/latest/releases_and_versioning.html>`__.
 
 Installation
 ------------
@@ -31,7 +30,7 @@ already expecting to find new plugins. The Heat configuration file in
 default locations the Heat engine seraches for new plugins. In the steps below
 we will link the plugins to a location where Heat is expecting new plugins to
 be. Please remember that your installation may differ (sometimes greatly) from
-the what we show below.
+ what we show below.
 
 *Note: If you are installing a pre-release version of the package with pip
 you will need to use the --pre option.*
@@ -102,10 +101,10 @@ templates.  An example use of one of the objects is below.
           partition: { get_resource: partition }
           template_name: test_template # Matches name in template resource
 
+
 Documentation
 -------------
-Project documentation can be found on
-`Read The Docs <https://f5-openstack-heat-plugins.readthedocs.org>`__.
+Project documentation can be found on `Read The Docs <https://f5-openstack-heat-plugins.readthedocs.org>`_.
 
 Filing Issues
 -------------
@@ -115,7 +114,7 @@ you found and how you found it.
 
 Contributing
 ------------
-See `Contributing <CONTRIBUTING.md>`__
+See `Contributing <CONTRIBUTING.md>`_.
 
 Build
 -----
@@ -123,47 +122,42 @@ To make a PyPI package...
 
 .. code:: bash
 
-    python setup.py sdist
+    $ python setup.py sdist
+
 
 Test
 ----
-Before you open a pull request, your code must have passing
-`pytest <http://pytest.org>`__ unit tests. In addition, you should
-include a set of functional tests written to use a real BIG-IP device
-for testing. Information on how to run our set of tests is included
-below.
+Before you open a pull request, your code must have passing `pytest <http://pytest.org>`__ unit tests. In addition, you should include a set of functional tests written to use a real BIG-IP®  device
+for testing. Information on how to run our set of tests is included below.
 
 Unit Tests
 ~~~~~~~~~~
-We use pytest for our unit tests
+We use pytest for our unit tests.
 
 #. If you haven't already, install the required test packages and the
    requirements.txt in your virtual environment.
 
-   .. code:: shell
+.. code:: shell
 
-       $ pip install hacking pytest pytest-cov
-       $ pip install -r requirements.txt
+   $ pip install hacking pytest pytest-cov
+   $ pip install -r requirements.txt
 
-#. | Run the tests and produce a coverage repor. The
-     ``--cov-report=html`` will
-   | create a ``htmlcov/`` directory that you can view in your browser
-     to see the
-   | missing lines of code.
-
-   .. code:: shell
-
-       py.test --cov ./icontrol --cov-report=html
-       open htmlcov/index.html
-
-Style Checks
-~~~~~~~~~~~~
-We use the hacking module for our style checks (installed as part of
-step 1 in the Unit Test section).
+#. Run the tests and produce a coverage report. The ``--cov-report=html`` will create a ``htmlcov/`` directory that you can view in your browser to see the missing lines of code.
 
 .. code:: shell
 
-    flake8 ./
+   $ py.test --cov ./icontrol --cov-report=html
+   $ open htmlcov/index.html
+
+
+Style Checks
+~~~~~~~~~~~~
+We use the hacking module for our style checks (installed as part of step 1 in the Unit Test section).
+
+.. code:: shell
+
+    $ flake8 ./
+
 
 Contact
 -------
@@ -196,7 +190,7 @@ permissions and limitations under the License.
 Contributor License Agreement
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Individuals or business entities who contribute to this project must
-have completed and submitted the `F5 Contributor License
+have completed and submitted the `F5® Contributor License
 Agreement <http://f5-openstack-docs.readthedocs.org/en/latest/cla_landing.html>`__
 to Openstack_CLA@f5.com prior to their code submission being included in this
 project.

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,5 +1,5 @@
-Maintenance and support of the unmodified F5 code is provided only to customers
-who have an existing support contract, purchased separately subject to F5’s
+Maintenance and support of the unmodified F5® code is provided only to customers
+who have an existing support contract, purchased separately subject to F5®’s
 support policies available at http://www.f5.com/about/guidelines-policies/ and 
-http://askf5.com.  F5 will not provide maintenance and support services of
-modified F5 code or code that does not have an existing support contract.
+http://askf5.com.  F5® will not provide maintenance and support services of
+modified F5® code or code that does not have an existing support contract.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,18 +1,18 @@
-F5 OpenStack Heat Plugins Documentation
-=======================================
+F5® OpenStack Heat Plugins
+==========================
 
-Introduction
-------------
-This repository houses all of F5's `Openstack Heat <https://wiki.openstack.org/wiki/Heat>`__
-resource plugins. F5's Heat plugins can be used to orchestrate BIG-IP services
+Overview
+--------
+This repository houses all of F5®'s `Openstack Heat <https://wiki.openstack.org/wiki/Heat>`__
+resource plugins. F5®'s Heat plugins can be used to orchestrate BIG-IP® services
 in your OpenStack environment.
 
 Releases and Versions
 ---------------------
 |release| supports the OpenStack |openstack_release| release.
 
-For more information about F5 Networks's OpenStack versioning and a support
-matrix please see `F5 Networks OpenStack Support Matrix <http://f5-openstack-docs.readthedocs.org/en/latest/releases_and_versioning.html>`__.
+For more information about F5 Networks®' OpenStack versioning and a support
+matrix, please see `F5 Networks®  OpenStack Support Matrix <http://f5-openstack-docs.readthedocs.org/en/latest/releases_and_versioning.html>`__.
 
 Installation
 ------------
@@ -26,10 +26,10 @@ already expecting to find new plugins. The Heat configuration file in
 default locations the Heat engine seraches for new plugins. In the steps below
 we will link the plugins to a location where Heat is expecting new plugins to
 be. Please remember that your installation may differ (sometimes greatly) from
-the what we show below.
+ what we show below.
 
-*Note: If you are installing a pre-release version of the package with pip
-you will need to use the --pre option.*
+.. note::
+    If you are installing a pre-release version of the package with pip, you will need to use the ``--pre`` option.
 
 Ubuntu
 ~~~~~~
@@ -57,15 +57,14 @@ RedHat/CentOS
 
 Usage
 -----
-Once the plugins are installed the F5 objects can be used when creating Heat
-templates.  An example use of one of the objects is below.
+Once the plugins are installed, you can use the F5® objects when creating Heat templates (example below).
 
 .. code:: yaml
 
     resources:
       # The first two resources defined here are requirements for deploying
-      # any object on the BigIP VE. The F5::BigIP::Device allows access and
-      # authentication to the BigIP on which an object will be configured.
+      # any object on the BIG-IP® VE. The F5::BigIP::Device allows access and
+      # authentication to the BIG-IP® on which an object will be configured.
       # The F5::Sys::Partition resource places a particular object in the
       # partition given. These two requirements will be linked with the obects
       # we intend to configure (iAppTemplate, iAppService) by calling the
@@ -97,6 +96,7 @@ templates.  An example use of one of the objects is below.
           partition: { get_resource: partition }
           template_name: test_template # Matches name in template resource
 
+
 API Documentation
 -----------------
 .. toctree::
@@ -111,11 +111,7 @@ Copyright 2015-2016 F5 Networks Inc.
 
 Support
 -------
-Maintenance and support of the unmodified F5 code is provided only to customers
-who have an existing support contract, purchased separately subject to F5’s
-support policies available at http://www.f5.com/about/guidelines-policies/ and
-http://askf5.com.  F5 will not provide maintenance and support services of
-modified F5 code or code that does not have an existing support contract.
+See `SUPPORT.md <https://github.com/F5Networks/f5-openstack-heat-plugins/blob/master/SUPPORT.md>`_.
 
 License
 -------
@@ -138,7 +134,7 @@ Contributor License Agreement
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Individuals or business entities who contribute to this project must
-have completed and submitted the `F5 Contributor License
+have completed and submitted the `F5® Contributor License
 Agreement <http://f5-openstack-docs.readthedocs.org/en/latest/cla_landing.html>`__
 to Openstack_CLA@f5.com prior to their code submission being included in this
 project.

--- a/f5_heat/resources/common/mixins.py
+++ b/f5_heat/resources/common/mixins.py
@@ -1,3 +1,5 @@
+# coding=utf-8
+#
 # Copyright 2015-2016 F5 Networks Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -30,10 +32,10 @@ def f5_bigip(func):
 
 
 class F5BigIPMixin(object):
-    '''This class is to be subclassed by an F5 Heat Resource Plugin.'''
+    '''This class is to be subclassed by an F5® Heat Resource Plugin.'''
 
     def get_bigip(self):
-        '''Retrieve the BigIP connection from the F5::BigIP resource.'''
+        '''Retrieve the BIG-IP® connection from the F5::BigIP resource.'''
 
         refid = self.properties[self.BIGIP_SERVER]
         self.bigip = self.stack.resource_by_refid(refid).get_bigip()

--- a/f5_heat/resources/f5_bigip_device.py
+++ b/f5_heat/resources/f5_bigip_device.py
@@ -1,3 +1,5 @@
+# coding=utf-8
+#
 # Copyright 2015-2016 F5 Networks Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/f5_heat/resources/f5_ltm_pool.py
+++ b/f5_heat/resources/f5_ltm_pool.py
@@ -1,3 +1,5 @@
+# coding=utf-8
+#
 # Copyright 2015-2016 F5 Networks Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -23,7 +25,7 @@ from common.mixins import F5BigIPMixin
 
 
 class F5LTMPool(resource.Resource, F5BigIPMixin):
-    '''Manages creation of an F5 Resource.'''
+    '''Manages creation of an F5® Resource.'''
 
     PROPERTIES = (
         NAME,

--- a/f5_heat/resources/f5_ltm_virtualserver.py
+++ b/f5_heat/resources/f5_ltm_virtualserver.py
@@ -1,3 +1,5 @@
+# coding=utf-8
+#
 # Copyright 2015-2016 F5 Networks Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -23,7 +25,7 @@ from common.mixins import F5BigIPMixin
 
 
 class F5LTMVirtualServer(resource.Resource, F5BigIPMixin):
-    '''Manages creation of an F5 Virtual Server Resource.'''
+    '''Manages creation of an F5® Virtual Server Resource.'''
 
     PROPERTIES = (
         NAME,

--- a/f5_heat/resources/f5_sys_iappcompositetemplate.py
+++ b/f5_heat/resources/f5_sys_iappcompositetemplate.py
@@ -1,3 +1,5 @@
+# coding=utf-8
+#
 # Copyright 2015-2016 F5 Networks Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -23,7 +25,7 @@ from common.mixins import F5BigIPMixin
 
 
 class F5SysiAppCompositeTemplate(F5BigIPMixin, resource.Resource):
-    '''Manages creation of an iApp resource on the BigIP device.'''
+    '''Manages creation of an iApp® resource on the BIG-IP® device.'''
 
     PROPERTIES = (
         NAME,
@@ -86,9 +88,9 @@ class F5SysiAppCompositeTemplate(F5BigIPMixin, resource.Resource):
     }
 
     def _add_optional_attr(self, iapp_dict):
-        '''When building the iapp dictionary, add optional items.
+        '''When building the iApp® dictionary, add optional items.
 
-        :param iapp_dict: dictionary for iapp template
+        :param iapp_dict: dictionary for iApp® template
         :returns: possibly modified dictionary
         '''
 
@@ -103,7 +105,7 @@ class F5SysiAppCompositeTemplate(F5BigIPMixin, resource.Resource):
         return iapp_dict
 
     def _build_iapp_dict(self):
-        '''Build dictionary for posting to BigIP.
+        '''Build dictionary for posting to BIG-IP®.
 
         :returns: dictionary of template information
         '''
@@ -122,7 +124,7 @@ class F5SysiAppCompositeTemplate(F5BigIPMixin, resource.Resource):
 
     @f5_common_resources
     def handle_create(self):
-        '''Create the template on the BigIP.
+        '''Create the template on the BIG-IP®.
 
         :raises: ResourceFailure
         '''
@@ -138,7 +140,7 @@ class F5SysiAppCompositeTemplate(F5BigIPMixin, resource.Resource):
 
     @f5_common_resources
     def handle_delete(self):
-        '''Delete the iApp Template on the BigIP.
+        '''Delete the iApp® Template on the BIG-IP®.
 
         :raises: ResourceFailure
         '''

--- a/f5_heat/resources/f5_sys_iappfulltemplate.py
+++ b/f5_heat/resources/f5_sys_iappfulltemplate.py
@@ -1,3 +1,5 @@
+# coding=utf-8
+#
 # Copyright 2015-2016 F5 Networks Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -28,7 +30,7 @@ class IappFullTemplateValidationFailed(exception.StackValidationFailed):
 
 
 class F5SysiAppFullTemplate(F5BigIPMixin, resource.Resource):
-    '''Manages creation of an iApp resource on the BigIP device.'''
+    '''Manages creation of an iApp® resource on the BIG-IP®.'''
 
     PROPERTIES = (
         BIGIP_SERVER,
@@ -82,7 +84,7 @@ class F5SysiAppFullTemplate(F5BigIPMixin, resource.Resource):
 
     @f5_common_resources
     def handle_create(self):
-        '''Create the template on the BigIP.
+        '''Create the template on the BIG-IP®.
 
         :raises: ResourceFailure
         '''
@@ -96,7 +98,7 @@ class F5SysiAppFullTemplate(F5BigIPMixin, resource.Resource):
 
     @f5_common_resources
     def handle_delete(self):
-        '''Delete the iApp Template on the BigIP.
+        '''Delete the iApp® Template on the BIG-IP®.
 
         :raises: ResourceFailure
         '''

--- a/f5_heat/resources/f5_sys_iappservice.py
+++ b/f5_heat/resources/f5_sys_iappservice.py
@@ -1,3 +1,5 @@
+# coding=utf-8
+#
 # Copyright 2015-2016 F5 Networks Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -30,7 +32,7 @@ LOG = logging.getLogger(__name__)
 
 
 class F5SysiAppService(resource.Resource, F5BigIPMixin):
-    '''Manages creation of an iApp resource on the BigIP device.'''
+    '''Manages creation of an iApp® resource on the BIG-IP®.'''
 
     PROPERTIES = (
         NAME,
@@ -131,7 +133,7 @@ class F5SysiAppService(resource.Resource, F5BigIPMixin):
 
     @f5_common_resources
     def handle_create(self):
-        '''Creates the iApp Service from an iApp template.
+        '''Creates the iApp® Service from an iApp® template.
 
         :raises: ResourceFailure # TODO Change to proper exception
         '''
@@ -147,7 +149,7 @@ class F5SysiAppService(resource.Resource, F5BigIPMixin):
 
     @f5_common_resources
     def handle_delete(self):
-        '''Deletes the iApp Service
+        '''Deletes the iApp® Service
 
         :raises: Resource Failure # TODO Change to proper exception
         '''

--- a/f5_heat/resources/f5_sys_partition.py
+++ b/f5_heat/resources/f5_sys_partition.py
@@ -1,3 +1,5 @@
+# coding=utf-8
+#
 # Copyright 2016 F5 Networks Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -23,7 +25,7 @@ from common.mixins import F5BigIPMixin
 
 
 class F5SysPartition(resource.Resource, F5BigIPMixin):
-    '''Manages creation of an F5 Virtual Server Resource.'''
+    '''Manages creation of an F5® Virtual Server Resource.'''
 
     PROPERTIES = (
         NAME,
@@ -65,10 +67,10 @@ class F5SysPartition(resource.Resource, F5BigIPMixin):
 
     @f5_bigip
     def handle_create(self):
-        '''Create the BigIP Virtual Server resource on the given device.
+        '''Create the BIG-IP® Virtual Server resource on the given device.
 
         If the 'Common' partition was specified, do not create, as it exists
-        on the BigIP by default.
+        on the BIG-IP® by default.
 
         :raises: ResourceFailure exception
         '''
@@ -84,10 +86,10 @@ class F5SysPartition(resource.Resource, F5BigIPMixin):
 
     @f5_bigip
     def handle_delete(self):
-        '''Delete the BigIP Virtual Server resource on the given device.
+        '''Delete the BIG-IP® Virtual Server resource on the given device.
 
         If the 'Common' partition was specified, do not delete, as it exists
-        on the BigIP by default.
+        on the BIG-IP® by default.
 
         :raises: ResourceFailure exception
         '''

--- a/f5_heat/resources/test/test_f5_ltm_pool.py
+++ b/f5_heat/resources/test/test_f5_ltm_pool.py
@@ -1,3 +1,5 @@
+# coding=utf-8
+#
 # Copyright 2015-2016 F5 Networks Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -11,6 +13,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+#
 #
 
 from f5_heat.resources import f5_ltm_pool


### PR DESCRIPTION
@pjbreaux 

Fixes #35 
#### What's this change do?
- made sure all non-code references to F5, F5 Networks, and F5 products use the appropriate trademarks.
- light edits to README, index.rst, CONTRIBUTING
- added venv/\* to .gitignore
#### Where should the reviewer start?

review the changes below
#### Any background context?

I ran flake8 locally and didn't get any errors, so I think everything should be good. We'll see what Travis says.
