### PR TITLE
Docs config updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ before_install:
 install:
     - pip install -r requirements.unit.test.txt
     - pip install -r ~/heat/requirements.txt
+    - pip install -r requirements.docs.txt
 script:
     - flake8 f5_heat/resources/
     - py.test f5_heat/resources/test --cov=f5_heat/resources

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -15,6 +15,7 @@
 
 import os
 import sys
+import f5_heat
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
@@ -39,6 +40,7 @@ extensions = [
     'sphinx.ext.todo',
     'sphinx.ext.ifconfig',
     'sphinx.ext.viewcode',
+    'sphinx.ext.autosectionlabel',
 ]
 
 # Add any paths that contain templates here, relative to this directory.
@@ -310,5 +312,13 @@ texinfo_documents = [
 # texinfo_no_detailmenu = False
 
 
-# Example configuration for intersphinx: refer to the Python standard library.
-intersphinx_mapping = {'https://docs.python.org/': None}
+# Map to other F5 projects
+intersphinx_mapping = {'heat': (
+    'http://f5-openstack-heat.readthedocs.io/en/kilo', None),
+    'lbaasv1': (
+    'http://f5-openstack-lbaasv1.readthedocs.io/en/1.0/', None),
+    #'lbaasv2': (
+    #'http://f5-openstack-lbaasv2-driver.readthedocs.io/en/liberty/', None),
+    'f5sdk': (
+    'http://f5-sdk.readthedocs.io/en/latest/', None),
+    }

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -29,7 +29,7 @@ from f5_heat import __version__ as VERSION
 # -- General configuration ------------------------------------------------
 
 # If your documentation needs a minimal Sphinx version, state it here.
-# needs_sphinx = '1.0'
+needs_sphinx = '1.4'
 
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,3 +1,5 @@
+.. _home:
+
 F5® OpenStack Heat Plugins
 ==========================
 

--- a/requirements.docs.txt
+++ b/requirements.docs.txt
@@ -1,2 +1,4 @@
 -e .
-Sphinx==1.3.5
+Sphinx>=1.4.1
+six>=1.10.0
+sphinx-rtd-theme


### PR DESCRIPTION
@pjbreaux 

Fixes #66 - Add intersphinx mapping and autosectionlabel to docs configs

I added the configurations to docs/conf.py that a)  make this doc set reference-able from the other F5 doc sets and b) automatically create section headers based on the section title.

**Note:**
This PR needs to be merged in before the one I'm going to assign to you shortly in the heat repo.
