### PR TITLE
Prepare heat plugins for installation in newton stack

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ before_install:
     - git config --global user.email "OpenStack_TravisCI@f5.com"
     - git config --global user.name "Travis F5 Openstack"
     - sudo apt-get -y install build-essential libssl-dev libffi-dev python-dev
-    - git clone -b stable/mitaka https://github.com/openstack/heat.git ~/heat
+    - git clone -b stable/newton https://github.com/openstack/heat.git ~/heat
 install:
     - pip install -r requirements.unit.test.txt
     - pip install -r ~/heat/requirements.txt

--- a/f5_heat/__init__.py
+++ b/f5_heat/__init__.py
@@ -1,2 +1,2 @@
-__version__ = u'9.0.2'
-__openstackrelease__ = u'mitaka'
+__version__ = u'10.0.0'
+__openstackrelease__ = u'newton'

--- a/requirements.func.test.txt
+++ b/requirements.func.test.txt
@@ -2,5 +2,5 @@
 .
 markupsafe
 git+https://github.com/F5Networks/pytest-symbols.git
-git+https://github.com/F5Networks/f5-openstack-test.git@mitaka
+git+https://github.com/F5Networks/f5-openstack-test.git@stable/newton
 hacking


### PR DESCRIPTION
@szakeri 

Issues:
Fixes #121

Problem:
In preparation for the newton release of this project, we need to ensure
we can install the plugins and run a travis build against a newton
OpenStack cluster. This ticket tracks the documentation, test
requirements, and any other changes that need to be made to accomplish
this.

Analysis:
Fixed references to mitaka in the travis file, __init__.py and the
functional requirements file.

Tests:
Letting travis build on my fork. If that passes, then we have
successfully run the unit tests. Also installed the plugins, using
Ansible, on a newton stack with TLC.