### PR TITLE
Liberty branch referring to upstream stable/liberty, which does not exist

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,10 @@ before_install:
     - git config --global user.email "OpenStack_TravisCI@f5.com"
     - git config --global user.name "Travis F5 Openstack"
     - sudo apt-get -y install build-essential libssl-dev libffi-dev python-dev
-    - git clone -b stable/liberty https://github.com/openstack/heat.git ~/heat
+    - git clone https://github.com/openstack/heat.git ~/heat
+    - cd ~/heat/
+    - git checkout tags/liberty-eol
+    - cd $TRAVIS_BUILD_DIR
 install:
     - pip install -r requirements.unit.test.txt
     - pip install -r ~/heat/requirements.txt

--- a/requirements.unit.test.txt
+++ b/requirements.unit.test.txt
@@ -1,5 +1,6 @@
 # These packages are required when testing the module
 .
+retrying
 hacking
 pytest
 pytest-cov


### PR DESCRIPTION
Issues:
Fixes #131

Problem:
The travis build for this repo requires the upstream (OpenStack) Heat
repo. We set this git clone to get the HEAD of the stable/liberty
branch. But that branch no longer exists in upstream because liberty was
EOLed. We need to set this to the git tag for the liberty EOL.

Analysis:
Set the proper git checkout of liberty-eol tag in the travis file. We
require this clone because we install the requirements.txt from the heat
repo. I would like to get away from that dependency eventually.

Tests:
Tested in travis.