### PR TITLE
newton qual code changes

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
     url='https://github.com/F5Networks/f5-openstack-heat-plugins/',
     keywords=['F5', 'openstack', 'heat', 'bigip', 'orchestration'],
     install_requires=[
-        'f5-sdk == 2.3.1'
+        'f5-sdk == 2.3.3'
     ],
     packages=find_packages(
         exclude=[

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
     url='https://github.com/F5Networks/f5-openstack-heat-plugins/',
     keywords=['F5', 'openstack', 'heat', 'bigip', 'orchestration'],
     install_requires=[
-        'f5-sdk == 1.0.0'
+        'f5-sdk == 2.3.1'
     ],
     packages=find_packages(
         exclude=[

--- a/test/functional/f5_ltm_pool/test_ltm_pool.py
+++ b/test/functional/f5_ltm_pool/test_ltm_pool.py
@@ -20,7 +20,7 @@ from pytest import symbols
 TEST_DIR = os.path.dirname(os.path.realpath(__file__))
 
 
-def test_create_complete(HeatStack, bigip):
+def test_create_complete(HeatStack, mgmt_root):
     HeatStack(
         os.path.join(TEST_DIR, 'success.yaml'),
         'success_test',
@@ -30,10 +30,10 @@ def test_create_complete(HeatStack, bigip):
             'bigip_pw': symbols.bigip_pw
         }
     )
-    assert bigip.tm.ltm.pools.pool.exists(
+    assert mgmt_root.tm.ltm.pools.pool.exists(
         name='test_pool', partition='Common'
     ) is True
-    loaded_pool = bigip.tm.ltm.pools.pool.load(
+    loaded_pool = mgmt_root.tm.ltm.pools.pool.load(
         name='test_pool', partition='Common'
     )
     assert loaded_pool.members_s.members.exists(
@@ -46,16 +46,16 @@ def test_create_complete(HeatStack, bigip):
 
 # Test causes other tests to fail because the test_partition cannot be deleted
 # This will be fixed in Issue #25 in f5-openstack-heat-plugins
-def itest_create_complete_new_partition(HeatStack, bigip):
+def itest_create_complete_new_partition(HeatStack, mgmt_root):
     hc, stack = HeatStack(os.path.join(TEST_DIR, 'new_partition.yaml'))
     assert hc.wait_until_status(stack.id, 'create_complete') is True
-    assert bigip.tm.ltm.pools.pool.exists(
+    assert mgmt_root.tm.ltm.pools.pool.exists(
         name='test_pool', partition='test_partition'
     ) is True
 
 
 # Copying this with a new template, which has no pool members
-def test_create_complete_new_partition(HeatStack, bigip):
+def test_create_complete_new_partition(HeatStack, mgmt_root):
     HeatStack(
         os.path.join(TEST_DIR, 'new_partition_no_members.yaml'),
         'new_partition_no_members_test',
@@ -65,12 +65,12 @@ def test_create_complete_new_partition(HeatStack, bigip):
             'bigip_pw': symbols.bigip_pw
         }
     )
-    assert bigip.tm.ltm.pools.pool.exists(
+    assert mgmt_root.tm.ltm.pools.pool.exists(
         name='test_pool', partition='test_partition'
     ) is True
 
 
-def test_create_failed_bad_members(HeatStack, bigip):
+def test_create_failed_bad_members(HeatStack, mgmt_root):
     with pytest.raises(Exception) as ex:
         HeatStack(
             os.path.join(TEST_DIR, 'bad_members.yaml'),
@@ -83,6 +83,6 @@ def test_create_failed_bad_members(HeatStack, bigip):
             expect_fail=True
         )
     assert 'Property member_port not assigned' in ex.value.message
-    assert bigip.tm.ltm.pools.pool.exists(
+    assert mgmt_root.tm.ltm.pools.pool.exists(
         name='test_pool', partition='Common'
     ) is False

--- a/test/functional/f5_ltm_virtualserver/test_ltm_virtualserver.py
+++ b/test/functional/f5_ltm_virtualserver/test_ltm_virtualserver.py
@@ -47,4 +47,5 @@ def test_create_complete_new_partition(HeatStack, mgmt_root):
     assert mgmt_root.tm.ltm.virtuals.virtual.exists(
         name='test_vs', partition='test_partition'
     ) is True
-    assert mgmt_root.tm.sys.folders.folder.exists(name='test_partition') is True
+    assert \
+        mgmt_root.tm.sys.folders.folder.exists(name='test_partition') is True

--- a/test/functional/f5_ltm_virtualserver/test_ltm_virtualserver.py
+++ b/test/functional/f5_ltm_virtualserver/test_ltm_virtualserver.py
@@ -19,7 +19,7 @@ from pytest import symbols
 TEST_DIR = os.path.dirname(os.path.realpath(__file__))
 
 
-def test_create_complete(HeatStack, bigip):
+def test_create_complete(HeatStack, mgmt_root):
     HeatStack(
         os.path.join(TEST_DIR, 'success.yaml'),
         'success_test',
@@ -29,12 +29,12 @@ def test_create_complete(HeatStack, bigip):
             'bigip_pw': symbols.bigip_pw
         }
     )
-    assert bigip.tm.ltm.virtuals.virtual.exists(
+    assert mgmt_root.tm.ltm.virtuals.virtual.exists(
         name='test_vs', partition='Common'
     ) is True
 
 
-def test_create_complete_new_partition(HeatStack, bigip):
+def test_create_complete_new_partition(HeatStack, mgmt_root):
     HeatStack(
         os.path.join(TEST_DIR, 'new_partition.yaml'),
         'new_partition_test',
@@ -44,7 +44,7 @@ def test_create_complete_new_partition(HeatStack, bigip):
             'bigip_pw': symbols.bigip_pw
         }
     )
-    assert bigip.tm.ltm.virtuals.virtual.exists(
+    assert mgmt_root.tm.ltm.virtuals.virtual.exists(
         name='test_vs', partition='test_partition'
     ) is True
-    assert bigip.tm.sys.folders.folder.exists(name='test_partition') is True
+    assert mgmt_root.tm.sys.folders.folder.exists(name='test_partition') is True

--- a/test/functional/f5_sys_iappcompositetemplate/test_sys_iappcompositetemplate.py
+++ b/test/functional/f5_sys_iappcompositetemplate/test_sys_iappcompositetemplate.py
@@ -20,7 +20,7 @@ from pytest import symbols
 TEST_DIR = os.path.dirname(os.path.realpath(__file__))
 
 
-def test_create_complete(HeatStack, bigip):
+def test_create_complete(HeatStack, mgmt_root):
     HeatStack(
         os.path.join(TEST_DIR, 'success.yaml'),
         'success_test',
@@ -30,12 +30,12 @@ def test_create_complete(HeatStack, bigip):
             'bigip_pw': symbols.bigip_pw
         }
     )
-    assert bigip.tm.sys.application.templates.template.exists(
+    assert mgmt_root.tm.sys.application.templates.template.exists(
         name='test_template', partition='Common'
     ) is True
 
 
-def test_create_complete_new_partition(HeatStack, bigip):
+def test_create_complete_new_partition(HeatStack, mgmt_root):
     HeatStack(
         os.path.join(TEST_DIR, 'new_partition.yaml'),
         'new_partition_test',
@@ -45,12 +45,12 @@ def test_create_complete_new_partition(HeatStack, bigip):
             'bigip_pw': symbols.bigip_pw
         }
     )
-    assert bigip.tm.sys.application.templates.template.exists(
+    assert mgmt_root.tm.sys.application.templates.template.exists(
         name='test_template', partition='test_partition'
     ) is True
 
 
-def test_create_failed_no_implementation(HeatStack, bigip):
+def test_create_failed_no_implementation(HeatStack, mgmt_root):
     with pytest.raises(Exception) as ex:
         HeatStack(
             os.path.join(TEST_DIR, 'no_implementation.yaml'),
@@ -62,7 +62,7 @@ def test_create_failed_no_implementation(HeatStack, bigip):
             },
             expect_fail=True
         )
-    assert bigip.tm.sys.application.templates.template.exists(
+    assert mgmt_root.tm.sys.application.templates.template.exists(
         name='test_template', partition='Common'
     ) is False
     assert 'Property implementation not assigned' in ex.value.message

--- a/test/functional/f5_sys_iappfulltemplate/test_sys_iappfulltemplate.py
+++ b/test/functional/f5_sys_iappfulltemplate/test_sys_iappfulltemplate.py
@@ -20,7 +20,7 @@ from pytest import symbols
 TEST_DIR = os.path.dirname(os.path.realpath(__file__))
 
 
-def test_create_complete(HeatStack, bigip):
+def test_create_complete(HeatStack, mgmt_root):
     HeatStack(
         os.path.join(TEST_DIR, 'success_common_partition.yaml'),
         'success_common_partition_test',
@@ -30,12 +30,12 @@ def test_create_complete(HeatStack, bigip):
             'bigip_pw': symbols.bigip_pw
         }
     )
-    assert bigip.tm.sys.application.templates.template.exists(
+    assert mgmt_root.tm.sys.application.templates.template.exists(
         name='thanks_world', partition='Common'
     ) is True
 
 
-def test_create_complete_new_partition(HeatStack, bigip):
+def test_create_complete_new_partition(HeatStack, mgmt_root):
     HeatStack(
         os.path.join(TEST_DIR, 'success_new_partition.yaml'),
         'success_new_partition_test',
@@ -45,7 +45,7 @@ def test_create_complete_new_partition(HeatStack, bigip):
             'bigip_pw': symbols.bigip_pw
         }
     )
-    assert bigip.tm.sys.application.templates.template.exists(
+    assert mgmt_root.tm.sys.application.templates.template.exists(
         name='thanks_world', partition='test_partition') is True
 
 
@@ -57,7 +57,7 @@ def itest_create_failed_literal_partition(HeatStack):
     # Heat teardown fails now due to bug: Issue #23 in github
 
 
-def test_create_failed_bad_iapp_parsing(HeatStack, bigip):
+def test_create_failed_bad_iapp_parsing(HeatStack, mgmt_root):
     with pytest.raises(Exception) as ex:
         HeatStack(
             os.path.join(TEST_DIR, 'bad_iapp.yaml'),
@@ -69,6 +69,6 @@ def test_create_failed_bad_iapp_parsing(HeatStack, bigip):
             },
             expect_fail=True
         )
-    assert bigip.tm.sys.application.templates.template.exists(
+    assert mgmt_root.tm.sys.application.templates.template.exists(
         name='thanks_world', partition='Common') is False
     assert 'NonextantSectionException' in ex.value.message

--- a/test/functional/f5_sys_iappservice/test_sys_iappservice.py
+++ b/test/functional/f5_sys_iappservice/test_sys_iappservice.py
@@ -20,7 +20,7 @@ from pytest import symbols
 TEST_DIR = os.path.dirname(os.path.realpath(__file__))
 
 
-def test_create_complete(HeatStack, bigip):
+def test_create_complete(HeatStack, mgmt_root):
     HeatStack(
         os.path.join(TEST_DIR, 'success.yaml'),
         'success_test',
@@ -30,11 +30,11 @@ def test_create_complete(HeatStack, bigip):
             'bigip_pw': symbols.bigip_pw
         }
     )
-    assert bigip.tm.sys.application.services.service.exists(
+    assert mgmt_root.tm.sys.application.services.service.exists(
         name='test_service', partition='Common') is True
 
 
-def test_create_complete_no_answers(HeatStack, bigip):
+def test_create_complete_no_answers(HeatStack, mgmt_root):
     HeatStack(
         os.path.join(TEST_DIR, 'success_no_answers.yaml'),
         'success_no_answers_test',
@@ -44,13 +44,13 @@ def test_create_complete_no_answers(HeatStack, bigip):
             'bigip_pw': symbols.bigip_pw
         }
     )
-    assert bigip.tm.sys.application.services.service.exists(
+    assert mgmt_root.tm.sys.application.services.service.exists(
         name='test_service', partition='Common') is True
-    assert bigip.tm.sys.application.templates.template.exists(
+    assert mgmt_root.tm.sys.application.templates.template.exists(
         name='test_template', partition='Common') is True
 
 
-def test_create_complete_new_partition(HeatStack, bigip):
+def test_create_complete_new_partition(HeatStack, mgmt_root):
     HeatStack(
         os.path.join(TEST_DIR, 'success_new_partition.yaml'),
         'success_new_partition_test',
@@ -60,17 +60,17 @@ def test_create_complete_new_partition(HeatStack, bigip):
             'bigip_pw': symbols.bigip_pw
         }
     )
-    assert bigip.tm.sys.application.services.service.exists(
+    assert mgmt_root.tm.sys.application.services.service.exists(
         name='test_service', partition='test_partition') is True
-    assert bigip.tm.sys.application.templates.template.exists(
+    assert mgmt_root.tm.sys.application.templates.template.exists(
         name='test_template', partition='test_partition') is True
-    assert bigip.tm.sys.folders.folder.exists(name='test_partition')
+    assert mgmt_root.tm.sys.folders.folder.exists(name='test_partition')
 
 
 # The stack deployed here depends on several pre-existing Openstack resources
 # A client image is used (ubuntu), a server image with a node server
 # pre-installed and networks.
-def itest_create_complete_lb_deploy(HeatStack, bigip):
+def itest_create_complete_lb_deploy(HeatStack, mgmt_root):
     hc, stack = HeatStack(
         os.path.join(TEST_DIR, 'lb_deploy.yaml'),
         'lb_deploy_test',
@@ -81,27 +81,27 @@ def itest_create_complete_lb_deploy(HeatStack, bigip):
         },
         teardown=False
     )
-    assert bigip.tm.sys.application.services.service.exists(
+    assert mgmt_root.tm.sys.application.services.service.exists(
         name='lb_service', partition='Common'
     ) is True
-    assert bigip.tm.sys.application.templates.template.exists(
+    assert mgmt_root.tm.sys.application.templates.template.exists(
         name='lb_template', partition='Common'
     ) is True
-    assert bigip.tm.ltm.virtuals.virtual.exists(
+    assert mgmt_root.tm.ltm.virtuals.virtual.exists(
         name='virtual_server1', partition='Common'
     ) is True
-    assert bigip.tm.ltm.pools.pool.exists(
+    assert mgmt_root.tm.ltm.pools.pool.exists(
         name='pool1', partition='Common'
     ) is True
     hc.delete_stack()
-    assert bigip.tm.sys.application.services.service.exists(
+    assert mgmt_root.tm.sys.application.services.service.exists(
         name='lb_service', partition='Common'
     ) is False
-    assert bigip.tm.sys.application.templates.template.exists(
+    assert mgmt_root.tm.sys.application.templates.template.exists(
         name='lb_template', partition='Common'
     ) is False
-    assert bigip.tm.ltm.virtuals.virtual.exists(
+    assert mgmt_root.tm.ltm.virtuals.virtual.exists(
         name='virtual_server1', partition='Common'
     ) is False
-    assert bigip.tm.ltm.pools.pool.exists(name='pool1', partition='Common') is \
+    assert mgmt_root.tm.ltm.pools.pool.exists(name='pool1', partition='Common') is \
         False

--- a/test/functional/f5_sys_partition/test_sys_partition.py
+++ b/test/functional/f5_sys_partition/test_sys_partition.py
@@ -32,7 +32,7 @@ def test_create_complete(HeatStack):
     )
 
 
-def test_create_complete_new_partition(HeatStack, bigip):
+def test_create_complete_new_partition(HeatStack, mgmt_root):
     hc, stack = HeatStack(
         os.path.join(TEST_DIR, 'new_partition.yaml'),
         'new_partition_test',
@@ -43,12 +43,12 @@ def test_create_complete_new_partition(HeatStack, bigip):
         },
         teardown=False
     )
-    assert bigip.tm.sys.folders.folder.exists(name='test_partition') is True
+    assert mgmt_root.tm.sys.folders.folder.exists(name='test_partition') is True
     hc.delete_stack(stack.id)
-    assert bigip.tm.sys.folders.folder.exists(name='test_partition') is False
+    assert mgmt_root.tm.sys.folders.folder.exists(name='test_partition') is False
 
 
-def test_create_failed_bad_subpath(HeatStack, bigip):
+def test_create_failed_bad_subpath(HeatStack, mgmt_root):
     msg = '(/BadSubPath) folder does not exist'
     hc, stack = HeatStack(
         os.path.join(TEST_DIR, 'bad_subpath.yaml'),
@@ -61,4 +61,4 @@ def test_create_failed_bad_subpath(HeatStack, bigip):
         expect_fail=True
     )
     assert msg in stack.stack_status_reason
-    assert bigip.tm.sys.folders.folder.exists(name='test_partition') is False
+    assert mgmt_root.tm.sys.folders.folder.exists(name='test_partition') is False

--- a/test/functional/f5_sys_partition/test_sys_partition.py
+++ b/test/functional/f5_sys_partition/test_sys_partition.py
@@ -43,9 +43,11 @@ def test_create_complete_new_partition(HeatStack, mgmt_root):
         },
         teardown=False
     )
-    assert mgmt_root.tm.sys.folders.folder.exists(name='test_partition') is True
+    assert \
+        mgmt_root.tm.sys.folders.folder.exists(name='test_partition') is True
     hc.delete_stack(stack.id)
-    assert mgmt_root.tm.sys.folders.folder.exists(name='test_partition') is False
+    assert \
+        mgmt_root.tm.sys.folders.folder.exists(name='test_partition') is False
 
 
 def test_create_failed_bad_subpath(HeatStack, mgmt_root):
@@ -61,4 +63,5 @@ def test_create_failed_bad_subpath(HeatStack, mgmt_root):
         expect_fail=True
     )
     assert msg in stack.stack_status_reason
-    assert mgmt_root.tm.sys.folders.folder.exists(name='test_partition') is False
+    assert \
+        mgmt_root.tm.sys.folders.folder.exists(name='test_partition') is False


### PR DESCRIPTION
@pjbreaux 

**What issues does this address?**
#123 ,  #124 , #125 , #126 , #127 , #128 

**What's this change do?**
This change will upgrade version of sdk to the latest version 2.3.1 and uses mgmt_root sdk fixture.

**Where should the reviewer start?**
setup.py and functional tests

**test_results:**
```
 bld-ml-zakeri:functional zakeri$ py.test -lv --symbols test_env.yaml .
<class 'f5.bigip.BigIP'>
== test session starts ==
platform darwin -- Python 2.7.12, pytest-3.0.1, py-1.4.34, pluggy-0.3.1 -- /Users/zakeri/.virtualenvs/heatplugin/bin/python
cachedir: ../../.cache
rootdir: /Users/zakeri/GitHub/f5-openstack-heat-plugins-1, inifile:
plugins: symbols-0.1.0a3, cov-2.2.1, f5-sdk-2.3.1, f5-openstack-test-0.2.1
collected 27 items

f5_bigip_device/test_bigip_device.py::test_create_complete PASSED
f5_bigip_device/test_bigip_device.py::test_create_failed_bad_ip PASSED
f5_bigip_device/test_bigip_device.py::test_create_failed_bad_password PASSED
f5_bigip_device/test_bigip_device.py::test_create_bad_property PASSED
f5_cm_cluster/test_cm_cluster.py::test_create_two_member PASSED
f5_cm_sync/test_cm_sync.py::test_create_complete PASSED
f5_cm_sync/test_cm_sync.py::test_create_complete_no_dg PASSED
f5_cm_sync/test_cm_sync.py::test_create_complete_bad_prop PASSED
f5_ltm_pool/test_ltm_pool.py::test_create_complete PASSED
f5_ltm_pool/test_ltm_pool.py::test_create_complete_new_partition PASSED
f5_ltm_pool/test_ltm_pool.py::test_create_failed_bad_members PASSED
f5_ltm_virtualserver/test_ltm_virtualserver.py::test_create_complete PASSED
f5_ltm_virtualserver/test_ltm_virtualserver.py::test_create_complete_new_partition PASSED
f5_sys_iappcompositetemplate/test_sys_iappcompositetemplate.py::test_create_complete PASSED
f5_sys_iappcompositetemplate/test_sys_iappcompositetemplate.py::test_create_complete_new_partition PASSED
f5_sys_iappcompositetemplate/test_sys_iappcompositetemplate.py::test_create_failed_no_implementation PASSED
f5_sys_iappfulltemplate/test_sys_iappfulltemplate.py::test_create_complete PASSED
f5_sys_iappfulltemplate/test_sys_iappfulltemplate.py::test_create_complete_new_partition PASSED
f5_sys_iappfulltemplate/test_sys_iappfulltemplate.py::test_create_failed_bad_iapp_parsing PASSED
f5_sys_iappservice/test_sys_iappservice.py::test_create_complete PASSED
f5_sys_iappservice/test_sys_iappservice.py::test_create_complete_no_answers PASSED
f5_sys_iappservice/test_sys_iappservice.py::test_create_complete_new_partition PASSED
f5_sys_partition/test_sys_partition.py::test_create_complete PASSED
f5_sys_partition/test_sys_partition.py::test_create_complete_new_partition PASSED
f5_sys_partition/test_sys_partition.py::test_create_failed_bad_subpath PASSED
f5_sys_save/test_sys_save.py::test_create_complete PASSED
f5_sys_save/test_sys_save.py::test_create_complete_bad_prop PASSED
======= 27 passed, 1 pytest-warnings in 365.13 seconds ===
```