### PR TITLE
Fixes #50 - incorrect resource provided in example

### DIFF
--- a/docs/README.rst
+++ b/docs/README.rst
@@ -106,7 +106,7 @@ Call the :func:`get_resource` function to link the required resources with the o
         name: Common                            # Put these objects in the /Common partition
         bigip_server: { get_resource: bigip }   # Create dependency on bigip
     iapp_template:
-      type: F5::Sys::iAppTemplate
+      type: F5::Sys::iAppFullTemplate
       properties:
         name: test_template
         bigip_server: { get_resource: bigip }   # Depends on bigip resource


### PR DESCRIPTION
@pjbreaux 

Fixes #50 
I have corrected the iApp resource provided in the F5 plugins usage example. 