### PR TITLE
Kilo.travis fix for docs.161

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ before_install:
     - cd $TRAVIS_BUILD_DIR
 install:
     - pip install -r requirements.unit.test.txt
+    - pip install -r requirements.docs.txt
     - pip install -r ~/heat/requirements.txt
 script:
     - flake8 f5_heat/resources/

--- a/requirements.docs.txt
+++ b/requirements.docs.txt
@@ -1,6 +1,6 @@
+-e .
 Sphinx>=1.6.2
 git+https://github.com/f5devcentral/f5-sphinx-theme@master
 cloud_sptheme
 sphinxjp.themes.basicstrap
 recommonmark
--e .


### PR DESCRIPTION
Fixing .travis.yml issues regarding docs

Issues:
WIP #161

Problem:
* Travis does not install the requirements.docs.txt prior to executing
    docs

Analysis:
* This change will have the travis instance install with `-e ./`
  * This will allow the importation of f5_heat

Tests:
* This is for the test suite.