### PR TITLE
Docs nav improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ before_install:
     - git config --global user.email "OpenStack_TravisCI@f5.com"
     - git config --global user.name "Travis F5 Openstack"
     - sudo apt-get -y install build-essential libssl-dev libffi-dev python-dev
-    - git clone -b stable/newton https://github.com/openstack/heat.git ~/heat
+    - git clone -b newton-eol https://github.com/openstack/heat.git ~/heat
 install:
     - pip install -r requirements.unit.test.txt
     - pip install -r ~/heat/requirements.txt

--- a/docs/_templates/breadcrumb.html
+++ b/docs/_templates/breadcrumb.html
@@ -1,0 +1,6 @@
+      <nav class="site-breadcrumb-nav site-nav">
+          <ul class="site-breadcrumb-list">
+            <li class="breadcrumb-item"><button type="button" id="sidebarCollapse" class="btn btn-info navbar-btn site-hidden"><i class="fa fa-align-justify"></i></button>&#x20 <a href="{{ theme_url_root }}">{{ theme_site_name|striptags|e }}</a> &gt; <a href="http://clouddocs.f5.com/cloud/openstack/latest/">F5 OpenStack Integrations </a> &gt; <a href="{{ pathto(master_doc) }}">{{ project|striptags|e }} </a> &gt; {{ title|striptags|e }}</li>
+          </ul>
+      </nav>
+      

--- a/docs/_templates/extralinks.html
+++ b/docs/_templates/extralinks.html
@@ -1,0 +1,4 @@
+<hr>
+<span class="nav-sidebartoc">
+<h5>View related articles on <a href="https://devcentral.f5.com/articles?tag=openstack" target="_blank">DevCentral <i class="fa fa-external-link-square"></i></a></h5>
+</span>


### PR DESCRIPTION
I made a few docs-nav updates to improve the user experience:

- Add devcentral link to sidebar (same as in the solution docs)
- Add link to the solution docs to the breadcrumb

I also had to change the reference to `stable/newton` in the travis-ci config to `newton-eol` to reflect the current state of the openstack/heat GitHub repo. 