### PR TITLE
Fix line length issues that are failing flake8 test

### DIFF
--- a/f5_heat/resources/f5_sys_iappcompositetemplate.py
+++ b/f5_heat/resources/f5_sys_iappcompositetemplate.py
@@ -150,8 +150,8 @@ class F5SysiAppCompositeTemplate(F5BigIPMixin, resource.Resource):
                 partition=self.partition_name
         ):
             try:
-                loaded_template = self.bigip.tm.sys.application.templates.template.\
-                    load(
+                loaded_template = self.bigip.tm.sys.application.templates.\
+                template.load(
                         name=self.properties[self.NAME],
                         partition=self.partition_name
                     )

--- a/f5_heat/resources/f5_sys_iappfulltemplate.py
+++ b/f5_heat/resources/f5_sys_iappfulltemplate.py
@@ -111,8 +111,8 @@ class F5SysiAppFullTemplate(F5BigIPMixin, resource.Resource):
                 partition=self.partition_name
         ):
             try:
-                loaded_template = self.bigip.tm.sys.application.templates.template.\
-                    load(
+                loaded_template = self.bigip.tm.sys.application.templates.\
+                template.load(
                         name=self.template_dict['name'],
                         partition=self.partition_name
                     )


### PR DESCRIPTION
See https://travis-ci.org/F5Networks/f5-openstack-heat-plugins/builds/426829459#L966

affects f5_heat/resources/f5_sys_iappcompositetemplate.py & f5_heat/resources/f5_sys_iappfulltemplate.py