### PR TITLE
Stop using _LE, make heat-engine not die in OpenStack Pike and later

### DIFF
--- a/f5_heat/resources/f5_sys_iappcompositetemplate.py
+++ b/f5_heat/resources/f5_sys_iappcompositetemplate.py
@@ -150,11 +150,11 @@ class F5SysiAppCompositeTemplate(F5BigIPMixin, resource.Resource):
                 partition=self.partition_name
         ):
             try:
-                loaded_template = self.bigip.tm.sys.application.templates.template.\
-                    load(
-                        name=self.properties[self.NAME],
-                        partition=self.partition_name
-                    )
+                templates = self.bigip.tm.sys.application.templates
+                loaded_template = templates.template.load(
+                    name=self.properties[self.NAME],
+                    partition=self.partition_name
+                )
                 loaded_template.delete()
             except Exception as ex:
                 raise exception.ResourceFailure(ex, None, action='DELETE')

--- a/f5_heat/resources/f5_sys_iappfulltemplate.py
+++ b/f5_heat/resources/f5_sys_iappfulltemplate.py
@@ -111,11 +111,11 @@ class F5SysiAppFullTemplate(F5BigIPMixin, resource.Resource):
                 partition=self.partition_name
         ):
             try:
-                loaded_template = self.bigip.tm.sys.application.templates.template.\
-                    load(
-                        name=self.template_dict['name'],
-                        partition=self.partition_name
-                    )
+                templates = self.bigip.tm.sys.application.templates
+                loaded_template = templates.template.load(
+                    name=self.template_dict['name'],
+                    partition=self.partition_name
+                )
                 loaded_template.delete()
             except Exception as ex:
                 raise exception.ResourceFailure(ex, None, action='DELETE')

--- a/f5_heat/resources/f5_sys_iappservice.py
+++ b/f5_heat/resources/f5_sys_iappservice.py
@@ -18,7 +18,6 @@
 
 from heat.common import exception
 from heat.common.i18n import _
-from heat.common.i18n import _LE
 from heat.engine import properties
 from heat.engine import resource
 
@@ -114,9 +113,7 @@ class F5SysiAppService(resource.Resource, F5BigIPMixin):
                 self.properties[prop_name]
             )
         except Exception:
-            LOG.error(
-                _LE("'%s' property failed to parse as JSON") % prop_name
-            )
+            LOG.error("'%s' property failed to parse as JSON" % prop_name)
             raise
 
     def _build_service_dict(self):


### PR DESCRIPTION
`from heat.common.i18n import _LE` can't work in OpenStack releases later than Ocata. Stop using it, and remove the import.

Fixes #166 for Pike.